### PR TITLE
9gag message order

### DIFF
--- a/plugins/9gag.lua
+++ b/plugins/9gag.lua
@@ -13,10 +13,9 @@ function get_9GAG()
 end
 
 function send_title(cb_extra, success, result)
-  --if success then
-    print("return called")
+  if success then
     send_msg(cb_extra[1], cb_extra[2], ok_cb, false)
-  --end
+  end
 end
 
 function run(msg, matches)


### PR DESCRIPTION
Hi,
In slow upload speed (for the bot) situations, when 9gag image is requested, the title is sent immediately, and the image takes some time in between.
This one makes sure that the title is sent immediately after the image is sent.
