### PR TITLE
Replace setuid with a more compatible approach

### DIFF
--- a/etc/telegram.conf
+++ b/etc/telegram.conf
@@ -6,5 +6,4 @@ respawn limit 15 5
 start on runlevel [2345]
 stop on shutdown
 
-setuid yourusername
-exec /bin/sh telegrambotpath/launch.sh
+exec su - yourusername -c"/bin/sh telegrambotpath/launch.sh"

--- a/etc/telegram.conf
+++ b/etc/telegram.conf
@@ -6,4 +6,4 @@ respawn limit 15 5
 start on runlevel [2345]
 stop on shutdown
 
-exec su - yourusername -c"/bin/sh telegrambotpath/launch.sh"
+exec su - yourusername; /bin/sh telegrambotpath/launch.sh


### PR DESCRIPTION
`setuid` emitted a `unknown stanza` error over the `setuid` line in my Raspberry Pi with Raspbmc (weird, it has upstart 1.6 and `setuid` stanza was included in upstart 1.4 AFAIK).

I think using `su - username -c"command"` may be more compatible as it relies completely on bash commands, not on upstart stanzas.

I couldn't check this in an environment other than my RPi, so please check it still works on your computer too.