### PR TITLE
Fix for Tweets without extended_entities

### DIFF
--- a/plugins/twitter.lua
+++ b/plugins/twitter.lua
@@ -47,7 +47,7 @@ function run(msg, matches)
   
   -- remove images
   local images = {}
-  if response.extended_entities.media then
+  if response.extended_entities and response.extended_entities.media then
     for k, v in pairs(response.extended_entities.media) do
         local url = v.url
         local pic = v.media_url


### PR DESCRIPTION
I had put https://twitter.com/FRCTeams/status/568890597009960961 into a chat, but there was no response save for:

```
 *** lua: plugins/twitter.lua:50: attempt to index field 'extended_entities' (a nil value)
```

This fixes that bug by checking for the existence of ``extended_entities`` before trying to get it's ``media``.