### PR TITLE
Enable/Disable bot on a channel

### DIFF
--- a/bot/bot.lua
+++ b/bot/bot.lua
@@ -177,7 +177,8 @@ function create_config( )
       "weather",
       "xkcd",
       "youtube" },
-    sudo_users = {our_id}  
+    sudo_users = {our_id},
+    disabled_channels = {}
   }
   serialize_to_file(config, './data/config.lua')
   print ('saved config into ./data/config.lua')

--- a/bot/bot.lua
+++ b/bot/bot.lua
@@ -47,6 +47,10 @@ function msg_valid(msg)
     print("Not valid, readed")
     return false
   end
+  if is_disabled(msg) then
+    print("Disabled channel")
+    return false
+  end
 end
 
 function do_lex(msg, text)

--- a/bot/bot.lua
+++ b/bot/bot.lua
@@ -170,6 +170,7 @@ function create_config( )
       "location",
       "media",
       "plugins",
+      "channels",
       "set",
       "stats",
       "time",

--- a/bot/utils.lua
+++ b/bot/utils.lua
@@ -146,6 +146,20 @@ function is_sudo(msg)
    return var
 end
 
+function is_disabled(msg)
+  local var = false
+  if msg.text == "!channel enable" then
+    return var
+  end
+  -- Check users id in config 
+  for v,channel in pairs(_config.disabled_channels) do 
+    if channel == msg.to.id then 
+      var = true 
+    end
+  end
+  return var
+end
+
 -- Returns the name of the sender
 function get_name(msg)
    local name = msg.from.first_name

--- a/plugins/channels.lua
+++ b/plugins/channels.lua
@@ -1,0 +1,48 @@
+function enable_channel( channel_id, channel_name )
+	-- Add to the config table
+	table.remove(_config.disabled_channels, get_index(channel_id))
+	save_config()
+	return "Channel "..channel_name.." enabled"
+end
+
+function disable_channel( channel_id, channel_name )
+	-- Disable
+	table.insert(_config.disabled_channels, channel_id)
+	save_config( )
+	return "Channel "..channel_name.." disabled"
+end
+
+function get_index( channel_id )
+	for k,v in pairs(_config.disabled_channels) do
+		if channel_id == v then
+			return k
+		end
+	end
+	-- If not found
+	return false
+end
+
+function run(msg, matches)
+	-- Enable a channel
+	if matches[1] == 'enable' then
+		print("enable: "..msg.to.id)
+		return enable_channel(msg.to.id, msg.to.title)
+	end
+	-- Disable a channel
+	if matches[1] == 'disable' then
+		print("disable: "..msg.to.id)
+		return disable_channel(msg.to.id, msg.to.title)
+	end
+end
+
+return {
+	description = "Plugin to manage channels. Enable or disable channel.", 
+	usage = {
+		"!channel enable: enable current channel",
+		"!channel disable: disable current channel" },
+	patterns = {
+		"^!channel? (enable)",
+		"^!channel? (disable)" }, 
+	run = run,
+	privileged = true
+}


### PR DESCRIPTION
Added option to silence bot on a channel. Only privileged user can use !channel enable/disable command to disabel or enable a channel. Id's of the disabled channels are hold in config.lua just like sudo users.