### PR TITLE
Make matches case insensitive

### DIFF
--- a/bot/bot.lua
+++ b/bot/bot.lua
@@ -80,7 +80,7 @@ function do_action(msg)
     -- print("Trying module", name)
     for k, pattern in pairs(desc.patterns) do
       -- print("Trying", text, "against", pattern)
-      matches = { string.match(text, pattern) }
+      matches = { string.match(text:lower(), pattern) }
       if matches[1] then
         mark_read(receiver, ok_cb, false)
         print("  matches", pattern)


### PR DESCRIPTION
This change makes command matching case insensitive. Case sensitivity is a problem for mobile Telegram clients that most likely use auto-correct and capitalisation, and often causes users to have to repeat messages to correct them. As far as I know from my testing, this shouldn't cause any visible changes to the string as it is only lowered for the purpose of matching, and commands such as !addquote won't be lowered in the final output.