### PR TITLE
Support Youtube links with "_" in their URL

### DIFF
--- a/plugins/youtube.lua
+++ b/plugins/youtube.lua
@@ -31,8 +31,8 @@ return {
   description = "Sends YouTube info and image.", 
   usage = "",
   patterns = {
-    "youtu.be/([A-Za-z0-9-]+)",
-    "youtube.com/watch%?v=([A-Za-z0-9-]+)",
+    "youtu.be/([_A-Za-z0-9-]+)",
+    "youtube.com/watch%?v=([_A-Za-z0-9-]+)",
   },
   run = run 
 }


### PR DESCRIPTION
Noticed when https://www.youtube.com/watch?v=rE3j_RHkqJc didn't gen anything.