### PR TITLE
Security additions & checks, host ip plugin

### DIFF
--- a/bot/bot.lua
+++ b/bot/bot.lua
@@ -75,8 +75,8 @@ function match_plugin(plugin, msg)
       -- Function exists
       if plugin.run ~= nil then
         -- If plugin is for privileged users only
-        if not user_allowed(plugin, msg) then
-          local text = 'This plugin requires privileged user'
+        if not user_allowed(plugin, msg) and pattern ~= ".*" then
+          local text = get_unprivileged_msg()
           send_msg(receiver, text, ok_cb, false)
         else
           -- Send the returned text by run function.
@@ -94,6 +94,10 @@ end
 
 -- Check if user can use the plugin
 function user_allowed(plugin, msg)
+  -- Check if privileged only option is set
+  if _config.sudo_only ~= nil and _config.sudo_only then
+    plugin.privileged = true
+  end
   if plugin.privileged and not is_sudo(msg) then
     return false
   end
@@ -182,7 +186,9 @@ function create_config( )
       "weather",
       "xkcd",
       "youtube" },
-    sudo_users = {our_id}  
+    sudo_users = {our_id},
+    sudo_only = false,
+    sudo_req_msg = "This plugin requires privileged user"
   }
   serialize_to_file(config, './data/config.lua')
   print ('saved config into ./data/config.lua')

--- a/bot/bot.lua
+++ b/bot/bot.lua
@@ -217,8 +217,14 @@ end
 function load_plugins()
   for k, v in pairs(_config.enabled_plugins) do
     print("Loading plugin", v)
-    local t = loadfile("plugins/"..v..'.lua')()
-    table.insert(plugins, t)
+    local t = loadfile("plugins/"..v..'.lua')
+    -- Make sure that we could load the file
+    if t ~= nil then
+     t=t()
+     table.insert(plugins, t)
+    else
+      print("Failed loading ",v)
+    end
   end
 end
 

--- a/bot/utils.lua
+++ b/bot/utils.lua
@@ -179,6 +179,17 @@ function is_sudo(msg)
   return var
 end
 
+-- Returns unpriviledged message
+function get_unprivileged_msg()
+  local var = 'This plugin requires privileged user';
+  -- dont let unprivleged users know that there is a telegram-bot
+  -- zero len msg -> zero iterations, no msg
+  if _config.sudo_req_msg ~= nil then
+    var = _config.sudo_req_msg
+  end
+  return var
+end
+
 -- Returns the name of the sender
 function get_name(msg)
   local name = msg.from.first_name

--- a/plugins/get_host_ip.lua
+++ b/plugins/get_host_ip.lua
@@ -1,0 +1,16 @@
+function run(msg, matches) 
+  text = http.request("http://ipinfo.io/ip") .. " "
+  return text
+end
+
+return {
+  description = "Return telegram-bot host public IP",
+  usage = {
+    "!getip: Returns hosts public IP"
+    },
+  patterns = {
+    "^!getip$"
+  },
+  run = run,
+  privileged = true
+}


### PR DESCRIPTION
With these changes you can now
* make all plugins only useable for privileged users
 * Option **sudo_only**    [bool]
* set a custom unprivileged message
 * Option **sudo_req_msg** [string]
 * empty string makes telegram-bot to return no msg -> sudo_req_msg = ""
* Make typos in plugin name without crashing the bot
* Retrieve public host ip from your telegram-bot (privileged)