### PR TITLE
Don't 0 index the array of images.

### DIFF
--- a/plugins/giphy.lua
+++ b/plugins/giphy.lua
@@ -9,7 +9,7 @@ local API_KEY = 'dc6zaTOxFJmzC' -- public beta key
 function get_image(response)
   local images = json:decode(response).data
   if #images == 0 then return nil end -- No images
-  local i = math.random(0,#images)
+  local i = math.random(1,#images)
   local image =  images[i] -- A random one
 
   if image.images.downsized then


### PR DESCRIPTION
This was causing random failures, whenever math.random selected 0, since that would always result in  an unhandled nil.