### PR TITLE
Add a calculator plugin

### DIFF
--- a/plugins/calculator.lua
+++ b/plugins/calculator.lua
@@ -1,0 +1,15 @@
+
+function run(msg, matches)
+  -- Convert expression to a function and execute it
+  local expression = string.gsub(matches[1], "(%a+)", "math.%1")
+  return load('return '..expression)()
+end
+
+return {
+  description = "A simple calculator plugin.",
+  usage = "!calc [expression]: calculates the mathematical expression",
+  patterns = {
+    "^!calc (.*)$"
+  },
+  run = run
+}

--- a/plugins/calculator.lua
+++ b/plugins/calculator.lua
@@ -9,7 +9,7 @@ return {
   description = "A simple calculator plugin.",
   usage = "!calc [expression]: calculates the mathematical expression",
   patterns = {
-    "^!calc (.*)$"
+    "^!calc ([%w%+%-%*%(%) ^%.%%/]+)$"
   },
   run = run
 }


### PR DESCRIPTION
This plugin calculates mathematical expressions using Lua's load() function.
Just doing this has a couple issues:
 - User of the command now has privileges to execute _any_ lua command
 - To access mathematical functions & constants, the user would need to use math.function()/constant

To go around this, I made the plugin replace all words in the expression with math.word. This should take care of both of the issues above.