### PR TITLE
Use strings as options for !vote

### DIFF
--- a/plugins/vote.lua
+++ b/plugins/vote.lua
@@ -65,8 +65,8 @@ function run(msg, matches)
       return "Voting statistics :\n" .. votes_result
     end
   else
-    save_vote(tostring(msg.to.id), msg.from.print_name, tostring(tonumber(matches[2])))
-    return "Vote registered : " .. msg.from.print_name .. " " .. tostring(tonumber(matches [2]))
+    save_vote(tostring(msg.to.id), msg.from.print_name, string.lower(tostring(matches[2])))
+    return "Vote registered : " .. msg.from.print_name .. " " .. tostring(matches [2])
   end
 end
 
@@ -80,7 +80,7 @@ return {
   patterns = {
     "^!vot(ing) (reset)",
     "^!vot(ing) (stats)",
-    "^!vot(e) ([0-9]+)$"
+    "^!vot(e) (.+)$"
   }, 
   run = run 
 }


### PR DESCRIPTION
Hi!

I find more convenient to have strings as options for !vote instead of just a number.
The usage and behaviour of the plugin keeps unchanged.