### PR TITLE
Process Service messages and custom message when user enter a chat.

### DIFF
--- a/bot/bot.lua
+++ b/bot/bot.lua
@@ -221,9 +221,7 @@ function create_config( )
       "xkcd",
       "youtube" },
     sudo_users = {our_id},
-    disabled_channels = {},
-    template_chat_new_user =  ""
-    -- Template parameters: {to_username} {from_username} {chat_name} {chat_id}
+    disabled_channels = {}
   }
   serialize_to_file(config, './data/config.lua')
   print ('saved config into ./data/config.lua')

--- a/plugins/service_entergroup.lua
+++ b/plugins/service_entergroup.lua
@@ -1,0 +1,63 @@
+local add_user_cfg = load_from_file('data/add_user_cfg.lua')
+
+local function template_add_user(base, to_username, from_username, chat_name, chat_id)
+   if to_username == "@" then
+      to_username = ''
+   end
+   if from_username == "@" then
+      from_username = ''
+   end
+   base = string.gsub(base, "{to_username}", to_username)
+   base = string.gsub(base, "{from_username}", from_username)
+   base = string.gsub(base, "{chat_name}", chat_name)
+   base = string.gsub(base, "{chat_id}", chat_id)
+   return base
+end
+
+function chat_new_user_link(msg)
+   local pattern = add_user_cfg.initial_chat_msg or ''
+   local to_username = '@' .. msg.from.username
+   local from_username = '[link](@' .. msg.action.link_issuer.username .. ')'
+   local chat_name = msg.to.print_name or ''
+   local chat_id = 'chat#id' .. msg.to.id
+   pattern = template_add_user(pattern, to_username, from_username, chat_name, chat_id)
+   if pattern ~= '' then
+      local receiver = get_receiver(msg)
+      send_msg(receiver, pattern, ok_cb, false)
+   end
+end
+
+function chat_new_user(msg)
+   local pattern = add_user_cfg.initial_chat_msg or ''
+   local to_username = '@' .. msg.action.user.username
+   local from_username = '@' .. msg.from.username
+   local chat_name = msg.to.print_name or ''
+   local chat_id = 'chat#id' .. msg.to.id
+   pattern = template_add_user(pattern, to_username, from_username, chat_name, chat_id)
+   if pattern ~= '' then
+      local receiver = get_receiver(msg)
+      send_msg(receiver, pattern, ok_cb, false)
+   end
+end
+
+
+local function run(msg, matches)
+   if not msg.realservice then
+      return "Are you trying to troll me?"
+   end
+   if matches[1] == "chat_add_user" then
+      chat_new_user(msg)
+   elseif mathes[1] == "chat_add_user_link" then
+      chat_new_user_link(msg)
+   end
+end
+
+return {
+   description = "Service plugin that sends a custom message when an user enters a chat.",
+   usage = "",
+   patterns = {
+      "^!!tgservice (chat_add_user)$",
+      "^!!tgservice (chat_add_user_link)$"
+   },
+   run = run
+}

--- a/plugins/service_template.lua
+++ b/plugins/service_template.lua
@@ -1,0 +1,18 @@
+local function run(msg, matches)
+   -- avoid this plugins to process user messages
+   if not msg.realservice then
+      -- return "Are you trying to troll me?"
+      return nil
+   end
+   print("Service message received: " .. matches[1])
+end
+
+
+return {
+   description = "Template for service plugins",
+   usage = "",
+   patterns = {
+      "^!!tgservice (.*)$" -- Do not use the (.*) match in your service plugin
+   },
+   run = run
+}


### PR DESCRIPTION
There are some messages that right now are ignored, but are so interesting.

I've added a function to process and do something in this messages.

And, the first use is the ability to send a message when a user enter a chat (invited or by link), that were asked in #169 and is interesting.

The message is setted in `data/config.lua` and the parameter in the table is `template_chat_new_user`, if it's empty string or nil it will be ignored and won't send any message.
But you can set to a string with some patterns that will be replaced by the values.

The full replace-values right now supported are:
- {to_username}: The username that have been invited, if the user have (@username)
- {from_username}: The username that have invited, if the user have one (@username or [link] (@username) if is by link)
- {chat_name}: The name of the chat (MyNiceChat)
- {chat_id}: The id of the chat (chat#id000000000)

One example that use all (what I have right now):
```lua
template_chat_new_user =  "Hi {to_username} to chat {chat_name} ({chat_id})!\nYou have been added by {from_username}"
```

I hope that you like it! 
I think that process service messages can be interesting :smile: 