### PR TITLE
Use ?split=false in dogify plugin

### DIFF
--- a/plugins/dogify.lua
+++ b/plugins/dogify.lua
@@ -1,8 +1,8 @@
 local function run(msg, matches)
    local base = "http://dogr.io/"
-   local path = string.gsub(matches[1], " ", "")
-   local url = base .. path .. '.png'
-   local urlm = "https?://[%w-_%.%?%.:/%+=&]+"
+   local path = string.gsub(matches[1], " ", "%%20")
+   local url = base .. path .. '.png?split=false&.png'
+   local urlm = "https?://[%%%w-_%.%?%.:/%+=&]+"
 
    if string.match(url, urlm) == url then
       local receiver = get_receiver(msg)


### PR DESCRIPTION
So I noticed a flaw in the dogify-plugin. It only works well for english, since it parses the words and automatically adds spaces between them.

Me being me, I took to twitter, and asked if there could be such a service as [dogr.io](http://dogr.io/)'s doge-as-a-service, but without the word parsing. [Here](https://twitter.com/wowdogr/status/604752878415278082)'s what I got. (linked [implementation commit](https://github.com/codazzo/dogr/commit/ca02086fb5dff59aa100f932e78eeb3c99ed3122))

Hence this pull-request. It's a simple change, but I think it would make the plugin a lot better to use.