### PR TITLE
Added send_order_msg function to utils

### DIFF
--- a/bot/utils.lua
+++ b/bot/utils.lua
@@ -447,7 +447,7 @@ function send_large_msg(destination, text)
     destination = destination,
     text = text
   }
-  send_order_msg_callback(cb_extra, true)
+  send_large_msg_callback(cb_extra, true)
 end
 
 -- If text is longer than 4096 chars, send multiple msg.


### PR DESCRIPTION
And removed some white spaces :stuck_out_tongue_closed_eyes: 

The use of the function is:
```lua
send_order_msg(receiver, table_msgs)
```

The contents of the table can be:
- A string: Will send the message
- A table with a pair of values: {type, path} where:
    - type is one of: 'document', 'audio', 'image', 'photo', 'video', 'file'.
    -  path is the pathfile (what `download_to_file` returns you)

For example:
``` lua
local function run(msg, matches)
    local messages = {'hi', 
                      {'audio', '/tmp/b.mp3'}, 
                      'How are you?', 
                      {'image', '/tmp/aaa.jpg'}, 
                      'bye!'}
    send_order_msg(get_receiver(msg), messages)
end
```