### PR TITLE
Add id plugin by default

### DIFF
--- a/bot/bot.lua
+++ b/bot/bot.lua
@@ -212,6 +212,7 @@ function create_config( )
       "google",
       "gps",
       "help",
+      "id",
       "images",
       "img_google",
       "location",


### PR DESCRIPTION
I think that the id plugin would be really great by default, so, you can know your id when you start the bot at the first time asking him, and then add it to the config data.