### PR TITLE
get_message, resolve_username and media_caption patch.

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -78,6 +78,7 @@ install() {
   git pull
   git submodule update --init --recursive
   patch -i "patches/disable-python-and-libjansson.patch" -p 0 --batch --forward
+  patch -i "patches/lua-tg.get_message.resolve_username.media_caption.patch" -p 0 --batch --forward
   RET=$?;
 
   cd tg

--- a/patches/lua-tg.get_message.resolve_username.media_caption.patch
+++ b/patches/lua-tg.get_message.resolve_username.media_caption.patch
@@ -1,0 +1,84 @@
+--- tg/lua-tg.c	2016-01-07 13:34:15.093728000 +0700
++++ tg/lua-tg.resolve_username.get_message.c	2016-01-07 13:42:27.780179744 +0700
+@@ -293,6 +293,7 @@
+   case tgl_message_media_document_encr:
+     lua_newtable (luaState);
+     lua_add_string_field ("type", "document");
++    lua_add_string_field ("caption", M->document->caption);
+     break;
+   case tgl_message_media_unsupported:
+     lua_newtable (luaState);
+@@ -718,7 +719,9 @@
+   lq_channel_invite_user,
+   lq_channel_kick_user,
+   lq_channel_get_admins,
+-  lq_channel_get_users
++  lq_channel_get_users,
++  lq_contact_search,
++  lq_get_message
+ };
+ 
+ struct lua_query_extra {
+@@ -1138,6 +1141,38 @@
+   free (cb);
+ }
+ 
++void lua_contact_search_cb (struct tgl_state *TLSR, void *cb_extra, int success, tgl_peer_t *C) {
++  assert (TLSR == TLS);
++  struct lua_query_extra *cb = cb_extra;
++  lua_settop (luaState, 0);
++  //lua_checkstack (luaState, 20);
++  my_lua_checkstack (luaState, 20);
++
++  lua_rawgeti (luaState, LUA_REGISTRYINDEX, cb->func);
++  lua_rawgeti (luaState, LUA_REGISTRYINDEX, cb->param);
++
++  lua_pushnumber (luaState, success);
++
++  if (success) {
++    push_peer (C->id, (void *)C);
++  } else {
++    lua_pushboolean (luaState, 0);
++  }
++
++  assert (lua_gettop (luaState) == 4);
++
++  int r = ps_lua_pcall (luaState, 3, 0, 0);
++
++  luaL_unref (luaState, LUA_REGISTRYINDEX, cb->func);
++  luaL_unref (luaState, LUA_REGISTRYINDEX, cb->param);
++
++  if (r) {
++    logprintf ("lua: %s\n",  lua_tostring (luaState, -1));
++  }
++
++  free (cb);
++}
++
+ #define LUA_STR_ARG(n) lua_ptr[n].str, strlen (lua_ptr[n].str)
+ 
+ void lua_do_all (void) {
+@@ -1363,6 +1398,14 @@
+       tgl_do_channel_get_members (TLS, lua_ptr[p + 1].peer_id, 100, 0, 0, lua_contact_list_cb, lua_ptr[p].ptr);
+       p += 2;
+       break;
++    case lq_contact_search:
++      tgl_do_contact_search (TLS, LUA_STR_ARG (p + 1), lua_contact_search_cb, lua_ptr[p].ptr);
++      p += 2;
++      break;
++    case lq_get_message:
++      tgl_do_get_message (TLS, &lua_ptr[p + 1].msg_id, lua_msg_cb, lua_ptr[p].ptr);
++      p += 2;
++      break;
+   /*
+   lq_delete_msg,
+   lq_restore_msg,
+@@ -1468,6 +1511,8 @@
+   {"channel_kick_user", lq_channel_kick_user, { lfp_channel, lfp_user, lfp_none }},
+   {"channel_get_admins", lq_channel_get_admins, { lfp_channel, lfp_none }},
+   {"channel_get_users", lq_channel_get_users, { lfp_channel, lfp_none }},
++  {"resolve_username", lq_contact_search, { lfp_string, lfp_none }},
++  {"get_message", lq_get_message, { lfp_msg, lfp_none }},
+   { 0, 0, { lfp_none}}
+ };
+ 


### PR DESCRIPTION
	modified:   launch.sh
	new file:   patches/lua-tg.get_message.resolve_username.media_caption.patch

Based on [`tg` #888 pull request](https://github.com/vysheng/tg/pull/888).

Example of `get_message` to get user `id` by reply:
```lua
do

  local function action_by_reply(extra, success, result)
    if result.from.username then
      user_name = '@'..result.from.username
    else
      user_name = ''
    end
    local text = 'Name: '..(result.from.first_name or '')..' '..(result.from.last_name or '')..'\n'
               ..'First name: '..(result.from.first_name or '')..'\n'
               ..'Last name: '..(result.from.last_name or '')..'\n'
               ..'User name: '..user_name..'\n'
               ..'ID: '..result.from.peer_id
    send_large_msg(extra.receiver, text)
  end

  local function run(msg)
    if msg.text == '!id' and msg.reply_id then
      get_message(msg.reply_id, action_by_reply, {receiver=get_receiver(msg)})
    end
  end
  
  return {
    decription = 'test id by_reply',
    usage = 'reply then type id',
    patterns = {
      '^!id$'
    },
    run = run
  }
        
end
```

Exampple of `resolve_username` to invite user by its username:
```lua
do

  local function resolve_username_cb(extra, success, result)    
    if success == 1 then
      chat_add_user('chat#id'..extra.msg.to.id, result.id, ok_cb, false)
    end
  end

--------------------------------------------------------------------------------

  local function run(msg, matches)
    if string.match(matches[1], '^@.+$') then
      resolve_username(string.gsub(matches[1], '@', ''), resolve_username_cb, {msg=msg})
    end
  end

--------------------------------------------------------------------------------

  return {
    description = 'Invite other user to the chat group.',
    usage = {
      ' !invite @[user_name] : Invite by their @[user_name].'
    },
    patterns = {
      '^!invite (@.*)$'
    },
    run = run
  }

end
```

Example of `media_caption` to warn sticker sender:
```lua
do
  
  local function pre_process(msg) 
    if msg.media and msg.media.caption == 'sticker.webp' then
      send_msg('chat#id'..msg.to.id, 'WARNING!\nDO NOT send sticker into this group!', ok_cb, true) 
    end
  end  

--------------------------------------------------------------------------------

  return {
    description = 'Warn sticker sender.',
    patterns = {
      '^!!tgservice (.+)$'
    },
    pre_process = pre_process
  }

end
```

